### PR TITLE
Comment in Site.conf.EXAMPLE for directory path

### DIFF
--- a/Site.conf.EXAMPLE
+++ b/Site.conf.EXAMPLE
@@ -18,7 +18,7 @@ $SITEINFO['password']='REPLACE_ME_TOO';
 // E-mail address for me
 $SITEINFO['AdministratorContact']='REPLACE_ME@EXAMPLE.COM';
 
-// Path to root directory
+// Path to root directory, must end with a slash
 $SITEINFO['docroot']='/var/www/REPLACE_ME/';
 
 // Standard public-facing domain name and port


### PR DESCRIPTION
Admin operations fail if the slash is omitted, clarifying this in the example conf.
